### PR TITLE
auto select text on click on dashboard

### DIFF
--- a/src/components/inputs/InputTemperature.vue
+++ b/src/components/inputs/InputTemperature.vue
@@ -10,6 +10,7 @@
     @input="updateValue"
     @update:error="onError"
     @keyup.enter="emitChange(newValue)"
+    @focus="$event.target.select()"
     label="target"
     type="number"
     suffix="°C"

--- a/src/components/widgets/ExtruderMovesWidget.vue
+++ b/src/components/widgets/ExtruderMovesWidget.vue
@@ -29,6 +29,7 @@
         <v-text-field
           v-model="extrudeLength"
           :disabled="!klippyConnected"
+          @focus="$event.target.select()"
           solo
           dense
           hide-details
@@ -40,6 +41,7 @@
         <v-text-field
           v-model="extrudeSpeed"
           :disabled="!klippyConnected"
+          @focus="$event.target.select()"
           solo
           dense
           hide-details


### PR DESCRIPTION
On the dashboard, clicking input puts the cursor in the box. On tablet/mobile, this causes you to have to click - then double click to highlight or click and delete to change input values.

This change automatically selects the value of the input box so you can just type a number and hit enter.