### PR TITLE
feat: Added a dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx
+
+RUN apt update -qq && apt install -y unzip
+WORKDIR /usr/share/nginx/html
+RUN curl -L https://github.com/cadriel/fluidd/releases/latest/download/fluidd.zip -o fluidd.zip
+RUN unzip -o fluidd.zip


### PR DESCRIPTION
Added a dockerfile that uses the `nginx` base image and downloads the latest release from github. I tried to build from source but I have non-reproductible issues in the container. Essentially, you could publish an image after a new release using this Dockerfile.
I also have `buildah` script if that's something you'd like to add.

A few things:

- We could run the `dist`command inside the container and remove the clutter with a multi stage build.
- We could also download the archive locally and then mount it inside the container to achieve the same result.
- I'll probably add a way to generate the config file at run time.