### PR TITLE
fix: ADJUSTED command added to 'additional commands' list

### DIFF
--- a/src/components/widgets/ConsoleEntryWidget.vue
+++ b/src/components/widgets/ConsoleEntryWidget.vue
@@ -30,6 +30,7 @@ export default class ConsoleEntryWidget extends Vue {
       'TESTZ',
       'ABORT',
       'ACCEPT',
+      'ADJUSTED',
       'GET_POSITION'
     ]
     additional.forEach(command => {


### PR DESCRIPTION
BED_SCREWS feature. The ADJUSTED command is not interactive.

// Adjust screw at 115.000,115.000. Then run ACCEPT, ADJUSTED, or ABORT
// Use ADJUSTED if a significant screw adjustment is made

Signed-off-by: Dmitrii Shakhovkin <demkaage@yandex.ru>