### PR TITLE
Update fluidd.xyz.md

### DIFF
--- a/docs/configuration/fluidd.xyz.md
+++ b/docs/configuration/fluidd.xyz.md
@@ -11,17 +11,17 @@ permalink: /configuration/fluidd_xyz
 
 ---
 
-Have mainsail installed, or don't want to install Fluidd locally? We support that!
+Have Mainsail installed, or don't want to install Fluidd locally? We support that!
 
-Fluidd is also hosted at `http://app.fluidd.xyz`. When you used in this way,
+Fluidd is also hosted at `http://app.fluidd.xyz`. When used in this way,
 Fluidd is downloaded to your browser.
 
 It has no interaction outside of your network unless configured to do so, and
 essentially works in the same way as hosting Fluidd yourself.
 
-FluiddPI comes OOB with support for this configuration built in.
+FluiddPi comes OOB with support for this configuration built in.
 
-If you've installed in some otehr way, then in order for fluidd to connect to
+If you've installed in some other way, then in order for Fluidd to connect to
 your printer, you'll need to configure Moonraker.
 
 In the `moonraker.conf` file is a section called `cors_domains:`.
@@ -29,7 +29,7 @@ The fluidd.xyz host must be in this section for a successful connection to be
 made.
 
 Generally, you can find the moonraker.conf file here
-`~/klipper_configuration/moonraker.conf` for Fluiddpi and Mainsail installs.
+`~/klipper_configuration/moonraker.conf` for FluiddPi and Mainsail installs.
 
 Alternatively, you can edit the file via the file browser in Fluidd.
 


### PR DESCRIPTION
Fix typo in 'other'. Make casing of "Mainsail" and "Fluidd" consistent and proper. Fix grammar issue with "When you used in this way", and removed the word "you".