### PR TITLE
Fixed a small glitch in the reprint menu

### DIFF
--- a/src/components/widgets/history/ReprintMenu.vue
+++ b/src/components/widgets/history/ReprintMenu.vue
@@ -9,6 +9,7 @@
         small
         v-bind="attrs"
         v-on="on"
+        class="ma-1"
       >
         <v-icon small left>
           $reprint


### PR DESCRIPTION
Before:

![Before](https://cdn.discordapp.com/attachments/795343328790315029/824772619236016128/unknown.png)

After:

![After](https://media.discordapp.net/attachments/795343328790315029/824772714287464459/unknown.png)