### PR TITLE
feat(console-help): Moved console help to a tooltip

### DIFF
--- a/src/components/widgets/console/ConsoleCard.vue
+++ b/src/components/widgets/console/ConsoleCard.vue
@@ -12,6 +12,16 @@
     @enabled="$emit('enabled', $event)"
     @collapsed="handleCollapseChange">
 
+    <template v-slot:title>
+      <v-icon left>$console</v-icon>
+      <span class="font-weight-light">{{ $t('app.general.title.console') }}</span>
+      <app-inline-help
+        bottom
+        small
+        :tooltip="$t('app.console.placeholder.command')"
+      ></app-inline-help>
+    </template>
+
     <template v-slot:menu>
       <v-checkbox
         v-model="hideTempWaits"

--- a/src/components/widgets/console/ConsoleCommand.vue
+++ b/src/components/widgets/console/ConsoleCommand.vue
@@ -12,7 +12,6 @@
           single-line
           dense
           hide-details
-          :placeholder="$t(`app.console.placeholder.command`)"
           @keyup.enter="emitSend(newValue)"
           @keyup.up="historyUp()"
           @keyup.down="historyDown()"


### PR DESCRIPTION
The help message was truncated and can be even longer with languages other than English.

Before:

<img width="690" alt="image" src="https://user-images.githubusercontent.com/137940/113620685-f4031d80-965a-11eb-9f1d-e3f005431b3b.png">

After:

<img width="801" alt="image" src="https://user-images.githubusercontent.com/137940/113620720-ffeedf80-965a-11eb-9499-6f50d2cd96f0.png">
