### PR TITLE
add feature-request and bug-report templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: Having issues? Start here!
-title: '[BUG]'
+title: ''
 labels: 'bug'
 assignees: ''
 
@@ -10,33 +10,40 @@ assignees: ''
 <!--
 Please try to fill in the form with as much detail, it makes the whole process easier for everyone, you included!
 
+Also include your version number before the title, e.g. []
+
 Thank you for using fluidd!
 -->
 
-## fluidd version
-(The version of the application this issue occurs with.)
+## Affected Version(s):
+(The versions of fluidd this issue occurs on.)
+- klipper version:
+- moonraker version:
+- fluidd version:
 
-**Platform**
-(Information about the operating system or devicethe issue occurs on.)
+## Platform:
+(Information about your platform, like the OS or browser you are using.)
 
-**Hardware Configuration**
-(Which printer was selected in Cura?)
+## Hardware Configuration:
+(Information about your hardware configuration. Like MCU, host and setup)
 
-**Reproduction Steps**
+## Reproduction Steps:
 1. (Something you did.)
 2. (Something you did next.)
 
-**Screenshot(s)**
-(Image showing the problem, perhaps before/after images.) 
+## Actual Results:
+(What happens after the reproduction steps have been followed.)
 
-**Actual results**
-(What happens after the above steps have been followed.)
+## Screenshot(s):
+(Images or gifs showing the problem, perhaps before/after.) 
 
-**Expected results**
-(What should happen after the above steps have been followed.)
+## Expected Results:
+(What *should* happen after the reproduction steps have been followed.)
 
-**Log file**
-(See https://github.com/Ultimaker/Cura#logging-issues to find the log file to upload, or copy a relevant snippet from it.)
+## Log Files:
+(The log files fluidd provides at Configure > System Control.)
+- klipper log:
+- moonraker log:
 
-**Additional information**
-(Extra information relevant to the issue.)
+## Additional information
+(Extra information relevant to the issue, links to similar issues.)

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Having issues? Start here!
+title: '[BUG]'
+labels: 'bug'
+assignees: ''
+
+---
+
+<!--
+Please try to fill in the form with as much detail, it makes the whole process easier for everyone, you included!
+
+Thank you for using fluidd!
+-->
+
+## fluidd version
+(The version of the application this issue occurs with.)
+
+**Platform**
+(Information about the operating system or devicethe issue occurs on.)
+
+**Hardware Configuration**
+(Which printer was selected in Cura?)
+
+**Reproduction Steps**
+1. (Something you did.)
+2. (Something you did next.)
+
+**Screenshot(s)**
+(Image showing the problem, perhaps before/after images.) 
+
+**Actual results**
+(What happens after the above steps have been followed.)
+
+**Expected results**
+(What should happen after the above steps have been followed.)
+
+**Log file**
+(See https://github.com/Ultimaker/Cura#logging-issues to find the log file to upload, or copy a relevant snippet from it.)
+
+**Additional information**
+(Extra information relevant to the issue.)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,25 +1,29 @@
 ---
 name: Feature Request
 about: Have a cool feature in mind? Use this template!
-title: '[FR]'
+title: ''
 labels: 'enhancement'
 assignees: ''
 
 ---
 
+<!--
+Please try to fill in the form with as much detail, it makes the whole process easier for everyone, you included!
 
+Thank you for using fluidd!
+-->
 
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 (A clear and concise description of what the problem is. Ex. I'm always frustrated when [...])
 
-**Describe the solution you'd like**
+## Describe the solution you'd like:
 (A clear and concise description of what you want to happen. If possible, describe why you think this is a good solution.)
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered:
 (A clear and concise description of any alternative solutions or features you've considered. Again, if possible, think about why these alternatives are not working out.)
 
-**Affected users and/or printers**
+## Affected users and/or setups:
 (Who do you think will benefit from this? Is everyone going to benefit from these changes? Or specific kinds of users?)
 
-**Additional context**
+## Additional Context:
 (Add any other context or screenshots about the feature request here.)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Have a cool feature in mind? Use this template!
+title: '[FR]'
+labels: 'enhancement'
+assignees: ''
+
+---
+
+
+
+**Is your feature request related to a problem? Please describe.**
+(A clear and concise description of what the problem is. Ex. I'm always frustrated when [...])
+
+**Describe the solution you'd like**
+(A clear and concise description of what you want to happen. If possible, describe why you think this is a good solution.)
+
+**Describe alternatives you've considered**
+(A clear and concise description of any alternative solutions or features you've considered. Again, if possible, think about why these alternatives are not working out.)
+
+**Affected users and/or printers**
+(Who do you think will benefit from this? Is everyone going to benefit from these changes? Or specific kinds of users?)
+
+**Additional context**
+(Add any other context or screenshots about the feature request here.)


### PR DESCRIPTION
as per the title, this PR aims to add feature-request and bug-report templates to make it easier for everyone to submit contributions and guide them through the process.

we should be clear to reuse these, they are based on Cura's old templates.
more about them [here](https://github.com/Ultimaker/Cura/tree/4.7/.github/ISSUE_TEMPLATE).

### TODOs:

- [x] ~~testing on my repo~~ TESTED AND WORKING;
- [x] pass checks;
- [ ] wait for @cadriel to give the go on licence;