### PR TITLE
fix(firefox-download): Fix ws disconnecting when downloading

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -97,6 +97,7 @@ export default class FilesMixin extends Vue {
     const link = document.createElement('a')
     link.href = url
     link.setAttribute('download', filename)
+    link.setAttribute('target', '_blank')
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)


### PR DESCRIPTION
When we download a file, we create a temporary link with a
download attribute. We then programatically click on it,
on Firefox this closes any ongoing WebSocket connection which
causes the application to go in a "disconnected" state.

See here for additional informations:

https://bugzilla.mozilla.org/show_bug.cgi?id=858538
https://bugzilla.mozilla.org/show_bug.cgi?id=896666

Until this is fixed, we added a `target="_blank"` attribute
as a workaround.