### PR TITLE
feat: add setting and speed accounting for time left

### DIFF
--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -65,6 +65,19 @@
           v-model="printTimeEstimateType">
         </v-select>
       </app-setting>
+
+      <v-divider></v-divider>
+
+      <app-setting
+        :title="$t('app.setting.label.account_for_speed')"
+      >
+        <v-switch
+          @click.native.stop
+          v-model="accountForSpeed"
+          hide-details
+          class="mb-5"
+        ></v-switch>
+      </app-setting>
     </v-card>
   </div>
 </template>
@@ -122,6 +135,18 @@ export default class GeneralSettings extends Mixins(StateMixin) {
   set printTimeEstimateType (value: string) {
     this.$store.dispatch('config/saveByPath', {
       path: 'uiSettings.general.printTimeEstimationsType',
+      value,
+      server: true
+    })
+  }
+
+  get accountForSpeed () {
+    return this.$store.state.config.uiSettings.general.accountForSpeed
+  }
+
+  set accountForSpeed (value: boolean) {
+    this.$store.dispatch('config/saveByPath', {
+      path: 'uiSettings.general.accountForSpeed',
       value,
       server: true
     })

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -284,6 +284,7 @@ app:
       mjpegstream: MJPEG Stream
       video: IP Camera
     label:
+      account_for_speed: Account for speed
       all_off: All off
       all_on: All on
       camera_fillspace: Fill space

--- a/src/store/config/index.ts
+++ b/src/store/config/index.ts
@@ -48,7 +48,8 @@ export const defaultState = (): ConfigState => {
         defaultToolheadZSpeed: 10,
         useGcodeCoords: false,
         zAdjustDistances: [0.005, 0.01, 0.025, 0.050],
-        enableNotifications: true
+        enableNotifications: true,
+        accountForSpeed: false
       },
       theme: {
         isDark: true,

--- a/src/store/config/types.ts
+++ b/src/store/config/types.ts
@@ -45,6 +45,7 @@ export interface GeneralConfig {
   useGcodeCoords: boolean;
   zAdjustDistances: number[];
   enableNotifications: boolean;
+  accountForSpeed: boolean;
 }
 
 export interface ThemeConfig {

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -112,6 +112,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
    */
   getTimeEstimates: (state, getters, rootState): TimeEstimates => {
     const type = rootState.config?.uiSettings.general.printTimeEstimationsType || 'file'
+    const speedCorrection = rootState.config?.uiSettings.general.accountForSpeed || false
     const progress = getters.getPrintProgress
     const current = (
       'print_stats' in state.printer &&
@@ -162,6 +163,11 @@ export const getters: GetterTree<PrinterState, RootState> = {
         total = 0
         remaining = 0
       }
+    }
+
+    if (speedCorrection) { // Account for the speed.
+      const speed = state.printer.gcode_move.speed_factor - 1
+      remaining = remaining - (remaining * speed)
     }
 
     return {


### PR DESCRIPTION
Add a setting that tweaks the calculation of time remaining to take into account the speed

Signed-off-by: Cory Redmond <code@cory.red>

**100%**
![100 percent rate](https://user-images.githubusercontent.com/1748564/115977118-d72c7c80-a56c-11eb-8265-c5ec96b4e796.png)

**50%**
![50 percent rate](https://user-images.githubusercontent.com/1748564/115977122-e3b0d500-a56c-11eb-800b-cbbc9a31444d.png)

**150%**
![150 percent rate](https://user-images.githubusercontent.com/1748564/115977127-ef040080-a56c-11eb-83c5-c2a86b91f5aa.png)

**Settings page**
![settings page](https://user-images.githubusercontent.com/1748564/115977128-f9be9580-a56c-11eb-8f9e-f7a19f09183c.png)
