### PR TITLE
Build ARMv6 Docker images for Raspberry Pi Zero

### DIFF
--- a/.github/workflows/multiarch_dockerhub.yml
+++ b/.github/workflows/multiarch_dockerhub.yml
@@ -56,7 +56,7 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           build-args: |


### PR DESCRIPTION
I got Klipper and Mainsail running on a Raspberry Pi Zero (see https://github.com/dimalo/klipper-web-control-docker/issues/7, needed ARM32v6 images built and Docker 20), but Fluidd is also lacking ARM32v6 images