### PR TITLE
fix: division by zero and infinite loop in file upload/download dialogs

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -84,11 +84,15 @@ export default class FilesMixin extends Vue {
       ...options,
       onDownloadProgress: (progressEvent: ProgressEvent) => {
         const units = ['kB', 'MB', 'GB']
-        let speed = progressEvent.loaded / (performance.now() - startTime)
+        let speed = 0
         let i = 0
-        while (speed > 1024) {
-          speed /= 1024.0
-          i = Math.min(2, i + 1)
+        const delta = performance.now() - startTime
+        if (delta > 0) {
+          speed = progressEvent.loaded / delta
+          while (speed > 1024) {
+            speed /= 1024
+            i = Math.min(2, i + 1)
+          }
         }
 
         const payload: any = {
@@ -172,11 +176,15 @@ export default class FilesMixin extends Vue {
           },
           onUploadProgress: (progressEvent: ProgressEvent) => {
             const units = ['kB', 'MB', 'GB']
-            let speed = progressEvent.loaded / (performance.now() - startTime)
+            let speed = 0
             let i = 0
-            while (speed > 1024) {
-              speed /= 1024.0
-              i = Math.min(2, i + 1)
+            const delta = performance.now() - startTime
+            if (delta > 0) {
+              speed = progressEvent.loaded / delta
+              while (speed > 1024) {
+                speed /= 1024
+                i = Math.min(2, i + 1)
+              }
             }
             this.$store.dispatch('files/updateFileUpload', {
               filepath,


### PR DESCRIPTION
With `privacy.resistFingerprinting` enabled in Firefox-based browsers the precision of `performance.now()` is reduced to 100 ms. On most machines I've tested this leads to a division by zero in the transfer progress speed calculation when the a file upload/download starts (in less than 100 ms), subsequently the script enters an infinite loop (as speed is assigned `Infinity`) and the tab freezes. Fix this by explicitly requiring a positive delta before starting to calculate transfer speed, I can confirm that editing and saving files through Fluidd now works on all affected machines on my end.

Signed-off-by: Dennis Marttinen <twelho@welho.tech>