### PR TITLE
Add absolute end time estimate

### DIFF
--- a/src/components/widgets/status/PrintStatus.vue
+++ b/src/components/widgets/status/PrintStatus.vue
@@ -20,7 +20,8 @@
               </template>
               <span>{{ $t('app.printer.status.time_left') }}</span>
             </v-tooltip>
-            {{ timeEstimates.remaining }}
+            <span>{{ timeEstimates.remaining }}</span>
+            <span class="grey--text text--darken-2" v-if="printerPrinting && printTimeEstimationsType !== 'totals'"> / {{ timeEstimates.endTime }}</span>
           </div>
           <div class="mb-1 grey--text text--lighten-1">
             <v-tooltip left>

--- a/src/plugins/filters.ts
+++ b/src/plugins/filters.ts
@@ -78,6 +78,20 @@ export const Filters = {
   },
 
   /**
+   * Formats a date from unixtime into a human readable
+   * datetime with optional formats for today and
+   * future datetimes
+   */
+  formatAbsoluteDateTime: (datetime: number, todayFormat?: string, futureFormat?: string) => {
+    const date = _Vue.$dayjs(datetime * 1000)
+    // Including a year doesn't make sense as that'll be clear from context (even on newyears-related edge cases)
+    const defaultFormat = 'MMM D, h:mm A'
+    const appropriateSpecifiedFormat = date.isToday() ? todayFormat : futureFormat
+
+    return date.format(appropriateSpecifiedFormat || defaultFormat)
+  },
+
+  /**
    * Formats a string into camel case.
    */
   camelCase: (string: string) => {
@@ -223,6 +237,7 @@ declare module 'vue/types/vue' {
     startCase(string: string): string;
     capitalize(string: string): string;
     formatDateTime(datetime: number, format?: string): string;
+    formatAbsoluteDateTime(datetime: number, todayFormat?: string, futureFormat?: string): string;
     getReadableFileSizeString(fileSizeInBytes: number): string;
     getReadableLengthString(lengthInMm: number): string;
     getApiUrls(url: string): ApiConfig;

--- a/src/store/printer/getters.ts
+++ b/src/store/printer/getters.ts
@@ -121,6 +121,8 @@ export const getters: GetterTree<PrinterState, RootState> = {
       : 0
     let total = 0
     let remaining = 0
+    // Current time as a Unix timestamp (in seconds)
+    let endTime = Math.floor(Date.now() / 1000)
 
     switch (type) {
       case 'slicer': {
@@ -130,7 +132,8 @@ export const getters: GetterTree<PrinterState, RootState> = {
         ) {
           total = state.printer.current_file.estimated_time
         }
-        remaining = (total - current)
+        remaining = total - current
+        endTime = endTime + remaining
         break
       }
       case 'filament': {
@@ -144,6 +147,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
           total = current / (state.printer.print_stats.filament_used / state.printer.current_file.filament_total)
         }
         remaining = total - current
+        endTime = endTime + remaining
         break
       }
       case 'file': {
@@ -151,6 +155,7 @@ export const getters: GetterTree<PrinterState, RootState> = {
           ? current / progress
           : current
         remaining = total - current
+        endTime = endTime + remaining
         break
       }
       case 'totals': { // totals only.
@@ -169,7 +174,8 @@ export const getters: GetterTree<PrinterState, RootState> = {
       progress: (progress * 100).toFixed(), // percent
       total: Vue.$filters.formatCounterTime(total), // total estimated time
       current: Vue.$filters.formatCounterTime(current), // current duration / time
-      remaining: Vue.$filters.formatCounterTime(remaining) // remaining time
+      remaining: Vue.$filters.formatCounterTime(remaining), // remaining time
+      endTime: Vue.$filters.formatAbsoluteDateTime(endTime, 'h:mm A') // estimated completion datetime
     }
   },
 

--- a/src/store/printer/types.ts
+++ b/src/store/printer/types.ts
@@ -17,6 +17,7 @@ export interface TimeEstimates {
   remaining: string;
   current: string;
   total: string;
+  endTime: string;
 }
 
 export interface Heater {

--- a/tests/unit/filters.spec.ts
+++ b/tests/unit/filters.spec.ts
@@ -57,6 +57,19 @@ describe('formatDateTime', () => {
   })
 })
 
+// formatAbsoluteDateTime
+
+describe('formatAbsoluteDateTime', () => {
+  Vue.use(DayJSPlugin)
+  it('renders numbers as date with offset applied', () => {
+    // This should return based on your browsers local time, given unixtime.
+    const d = new Date(0)
+    const offset = d.getTimezoneOffset()
+    const d2 = new Date(d.getTime() + offset * 60)
+    expect(Filters.formatAbsoluteDateTime(d2.getTime())).to.equal('Jan 1, 12:00 AM')
+  })
+})
+
 // getReadableLengthString
 
 describe('getReadableLengthString', () => {


### PR DESCRIPTION
Addresses #295.

Adds an estimate of the real-world print completion estimation to the print status card.  Has three main states:

- Hidden when not printing
- When the estimate is in the same day a straight hours/minutes end estimate is given
- When the estimate is further in the future the estimated end date is also included

![Screen Shot 2021-06-14 at 3 59 35 PM](https://user-images.githubusercontent.com/569917/121977925-e98c9080-cd3b-11eb-863a-0b3ea223c678.png)
![Screen Shot 2021-06-14 at 3 53 47 PM](https://user-images.githubusercontent.com/569917/121977924-e8f3fa00-cd3b-11eb-9801-0a222bad8f02.png)
![Screen Shot 2021-06-14 at 4 03 07 PM](https://user-images.githubusercontent.com/569917/121977926-ea252700-cd3b-11eb-97d2-e4582adc2a48.png)
