### PR TITLE
Bugfix: make temperature labels visible in light mode

### DIFF
--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -198,15 +198,12 @@ export default class TemperatureTargets extends Mixins(StateMixin) {
 <style lang="scss" scoped>
   @import '~vuetify/src/styles/styles.sass';
   ::v-deep .v-data-table.temperature-table > .v-data-table__wrapper > table {
-    color: rgba(map-deep-get($material-theme, 'text', 'theme'), 0.55);
-
     .temp-name,
     .temp-power {
       font-size: 1rem;
     }
 
     .temp-actual {
-      color: rgba(map-deep-get($material-theme, 'text', 'theme'), 0.55);
       font-weight: 300;
       font-size: 1.125rem;
     }


### PR DESCRIPTION
Addresses #319

The SCSS for temp table labels seemed to be using some outdated mechanism to change color based on theme (I couldn't find any other examples of this mechanism, anyway).  

By simply removing these lines it now delegates to the global app stylesheet
![Screen Shot 2021-06-15 at 4 35 02 PM](https://user-images.githubusercontent.com/569917/122136809-1f8f4a80-cdf8-11eb-8f80-6bb7931510dd.png)
![Screen Shot 2021-06-15 at 4 35 13 PM](https://user-images.githubusercontent.com/569917/122136812-20c07780-cdf8-11eb-898d-88f75e57999b.png)

.
