### PR TITLE
Fix: gcode preview load current file

### DIFF
--- a/src/mixins/files.ts
+++ b/src/mixins/files.ts
@@ -52,7 +52,7 @@ export default class FilesMixin extends Vue {
 
     if (res) {
       this.cancelTokenSource = Axios.CancelToken.source()
-      const path = file.path ? `${file.path}/${file.filename}` : file.filename
+      const path = file.path ? `${file.path}/${file.name}` : file.filename
       return await this.getFile(path, 'gcodes', file.size, {
         responseType: 'text',
         transformResponse: [v => v],


### PR DESCRIPTION
- if the file is in a subfolder the path is incorrect
By: Biorn1950 (biorn@me.com)