### PR TITLE
Added power "usage" and "humidity" unit support in ThermalChart on temperature axis

### DIFF
--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -121,7 +121,7 @@
           <td class="temp-actual">
             <v-tooltip left>
               <template v-slot:activator="{ on, attrs }">
-                 <span v-bind="attrs" v-on="on">{{ item.temperature.toFixed(1) }}<small>{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</small></span>
+                <span v-bind="attrs" v-on="on">{{ item.temperature.toFixed(1) }}<small>{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</small></span>
               </template>
               <span v-if="item.measured_max_temp && item.measured_min_temp">
                 <span class="">{{ $t('app.general.label.high') }}: {{ item.measured_max_temp.toFixed(1) }}{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</span><br />

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -105,11 +105,9 @@
         </tr>
         <tr v-for="item in sensors" :key="item.name">
           <td>
-            <v-icon
-              small
-              :color="item.color">
-              $thermometer
-            </v-icon>
+            <v-icon v-if="item.name.includes('usage')" small :color="item.color">              $powerline            </v-icon>
+            <v-icon v-else-if="item.name.includes('humidity')" small :color="item.color">              $waterpercent            </v-icon>
+            <v-icon v-else small :color="item.color">              $thermometer            </v-icon>
           </td>
           <td class="temp-name">
             <span
@@ -123,12 +121,10 @@
           <td class="temp-actual">
             <v-tooltip left>
               <template v-slot:activator="{ on, attrs }">
-                <span v-bind="attrs" v-on="on">{{ item.temperature.toFixed(1) }}<small>°C</small></span>
-              </template>
+                 <span v-bind="attrs" v-on="on">{{ item.temperature.toFixed(1) }}<small>{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</small></span>              </template>
               <span v-if="item.measured_max_temp && item.measured_min_temp">
-                <span class="">{{ $t('app.general.label.high') }}: {{ item.measured_max_temp.toFixed(1) }}°C</span><br />
-                <span class="">{{ $t('app.general.label.low') }}: {{ item.measured_min_temp.toFixed(1) }}°C</span>
-              </span>
+                <span class="">{{ $t('app.general.label.high') }}: {{ item.measured_max_temp.toFixed(1) }}{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</span><br />
+                <span class="">{{ $t('app.general.label.low') }}: {{ item.measured_min_temp.toFixed(1) }}{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</span>              </span>
             </v-tooltip>
           </td>
           <td>&nbsp;</td>

--- a/src/components/widgets/thermals/TemperatureTargets.vue
+++ b/src/components/widgets/thermals/TemperatureTargets.vue
@@ -121,10 +121,12 @@
           <td class="temp-actual">
             <v-tooltip left>
               <template v-slot:activator="{ on, attrs }">
-                 <span v-bind="attrs" v-on="on">{{ item.temperature.toFixed(1) }}<small>{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</small></span>              </template>
+                 <span v-bind="attrs" v-on="on">{{ item.temperature.toFixed(1) }}<small>{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</small></span>
+              </template>
               <span v-if="item.measured_max_temp && item.measured_min_temp">
                 <span class="">{{ $t('app.general.label.high') }}: {{ item.measured_max_temp.toFixed(1) }}{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</span><br />
-                <span class="">{{ $t('app.general.label.low') }}: {{ item.measured_min_temp.toFixed(1) }}{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</span>              </span>
+                <span class="">{{ $t('app.general.label.low') }}: {{ item.measured_min_temp.toFixed(1) }}{{ (item.name.includes('usage')) ? 'W' : ((item.name.includes('humidity')) ? '%' : '°C') }}</span>
+              </span>
             </v-tooltip>
           </td>
           <td>&nbsp;</td>

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -181,7 +181,7 @@ export default class ThermalChart extends Vue {
                       ${param.seriesName}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
-                      ${param.value[param.seriesName].toFixed(2)}<small>°C</small>`
+                      ${param.value[param.seriesName].toFixed(2)}<small>${param.value[param.seriesName].toFixed(2)}<small>${(param.seriesName.includes('usage')) ? 'W' : ((param.seriesName.includes('humidity')) ? '%' : '°C')}</small>`
 
                 if (param.seriesName + 'Target' in param.value) {
                   text += ` / ${param.value[param.seriesName + 'Target'].toFixed()}<small>°C</small>`
@@ -234,7 +234,7 @@ export default class ThermalChart extends Vue {
       },
       yAxis: [
         {
-          name: 'Temperature °C',
+          name: 'Temperature °C / Watt W / Humidity %',
           nameTextStyle: {
             fontSize,
             color: fontColor,

--- a/src/components/widgets/thermals/ThermalChart.vue
+++ b/src/components/widgets/thermals/ThermalChart.vue
@@ -181,7 +181,7 @@ export default class ThermalChart extends Vue {
                       ${param.seriesName}:
                     </span>
                     <span style="float:right;margin-left:20px;font-size:${fontSize}px;color:${fontColor};font-weight:900">
-                      ${param.value[param.seriesName].toFixed(2)}<small>${param.value[param.seriesName].toFixed(2)}<small>${(param.seriesName.includes('usage')) ? 'W' : ((param.seriesName.includes('humidity')) ? '%' : '°C')}</small>`
+                      ${param.value[param.seriesName].toFixed(2)}<small>${(param.seriesName.includes('usage')) ? 'W' : ((param.seriesName.includes('humidity')) ? '%' : '°C')}</small>`
 
                 if (param.seriesName + 'Target' in param.value) {
                   text += ` / ${param.value[param.seriesName + 'Target'].toFixed()}<small>°C</small>`

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,4 +1,6 @@
 import {
+  mdiWaterPercent,
+  mdiTransmissionTower,
   mdiClose,
   mdiTune,
   mdiMinus,
@@ -175,6 +177,8 @@ export const Globals = Object.freeze({
 })
 
 export const Icons = Object.freeze({
+  waterpercent: mdiWaterPercent,
+  powerline: mdiTransmissionTower,
   dash: mdiViewDashboardOutline,
   account: mdiAccount,
   addAccount: mdiAccountPlus,


### PR DESCRIPTION
change units display, remain on first y-axis. maybe one needs to "open up" the widget for more sensors, because klipper might supply more than temperature output